### PR TITLE
Remove TODO from chat example

### DIFF
--- a/python/chat.py
+++ b/python/chat.py
@@ -76,8 +76,7 @@ class UnitTests(absltest.TestCase):
             print(chunk.text)
             print("_" * 80)
 
-        # TODO: Uncomment once google.genai gets support for retrieving chat.get_history()
-        # print(chat.get_history())
+        print(chat.get_history())
         # [END chat_streaming]
 
     def test_chat_streaming_with_images(self):


### PR DESCRIPTION
This is supported from 1.5.0 so we can get rid of this.