### PR TITLE
Update Go examples to use role constants (`RoleUser`, `RoleModel`)

### DIFF
--- a/go/cache.go
+++ b/go/cache.go
@@ -37,12 +37,12 @@ func CacheCreate() (*genai.GenerateContentResponse, error) {
 		genai.NewPartFromURI(document.URI, document.MIMEType),
 	}
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 	cache, err := client.Caches.Create(ctx, modelName, &genai.CreateCachedContentConfig{
 		Contents: contents,
 		SystemInstruction: genai.NewContentFromText(
-			"You are an expert analyzing transcripts.", "user",
+			"You are an expert analyzing transcripts.", genai.RoleUser,
 		),
 	})
 	if err != nil {
@@ -97,12 +97,12 @@ func CacheCreateFromName() (*genai.GenerateContentResponse, error) {
 		genai.NewPartFromURI(document.URI, document.MIMEType),
 	}
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 	cache, err := client.Caches.Create(ctx, modelName, &genai.CreateCachedContentConfig{
 		Contents:          contents,
 		SystemInstruction: genai.NewContentFromText(
-			"You are an expert analyzing transcripts.", "user",
+			"You are an expert analyzing transcripts.", genai.RoleUser,
 		),
 	})
 	if err != nil {
@@ -151,7 +151,7 @@ func CacheCreateFromChat() (*genai.GenerateContentResponse, error) {
 
 	// Create initial chat with a system instruction.
 	chat, err := client.Chats.Create(ctx, modelName, &genai.GenerateContentConfig{
-		SystemInstruction: genai.NewContentFromText(systemInstruction, "user"),
+		SystemInstruction: genai.NewContentFromText(systemInstruction, genai.RoleUser),
 	}, nil)
 	if err != nil {
 		log.Fatal(err)
@@ -199,7 +199,7 @@ func CacheCreateFromChat() (*genai.GenerateContentResponse, error) {
 	// To cache the conversation so far, pass the chat history as the list of contents.
 	cache, err := client.Caches.Create(ctx, modelName, &genai.CreateCachedContentConfig{
 		Contents:          chat.History(false),
-		SystemInstruction: genai.NewContentFromText(systemInstruction, "user"),
+		SystemInstruction: genai.NewContentFromText(systemInstruction, genai.RoleUser),
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -258,13 +258,13 @@ func CacheDelete() error {
 		genai.NewPartFromURI(document.URI, document.MIMEType),
 	}
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 
 	cache, err := client.Caches.Create(ctx, modelName, &genai.CreateCachedContentConfig{
 		Contents:          contents,
 		SystemInstruction: genai.NewContentFromText(
-			"You are an expert analyzing transcripts.", "user",
+			"You are an expert analyzing transcripts.", genai.RoleUser,
 		),
 	})
 	if err != nil {
@@ -306,13 +306,13 @@ func CacheGet() error {
 		genai.NewPartFromURI(document.URI, document.MIMEType),
 	}
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 
 	cache, err := client.Caches.Create(ctx, modelName, &genai.CreateCachedContentConfig{
 		Contents:          contents,
 		SystemInstruction: genai.NewContentFromText(
-			"You are an expert analyzing transcripts.", "user",
+			"You are an expert analyzing transcripts.", genai.RoleUser,
 		),
 	})
 	if err != nil {
@@ -358,12 +358,12 @@ func CacheList() error {
 		genai.NewPartFromURI(document.URI, document.MIMEType),
 	}
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 	cache, err := client.Caches.Create(ctx, modelName, &genai.CreateCachedContentConfig{
 		Contents:          contents,
 		SystemInstruction: genai.NewContentFromText(
-			"You are an expert analyzing transcripts.", "user",
+			"You are an expert analyzing transcripts.", genai.RoleUser,
 		),
 	})
 	if err != nil {
@@ -425,12 +425,12 @@ func CacheUpdate() error {
 		genai.NewPartFromURI(document.URI, document.MIMEType),
 	}
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 	cache, err := client.Caches.Create(ctx, modelName, &genai.CreateCachedContentConfig{
 		Contents:          contents,
 		SystemInstruction: genai.NewContentFromText(
-			"You are an expert analyzing transcripts.", "user",
+			"You are an expert analyzing transcripts.", genai.RoleUser,
 		),
 	})
 	if err != nil {

--- a/go/chat.go
+++ b/go/chat.go
@@ -24,8 +24,8 @@ func Chat() error {
 
 	// Pass initial history using the History field.
 	history := []*genai.Content{
-		genai.NewContentFromText("Hello", "user"),
-		genai.NewContentFromText("Great to meet you. What would you like to know?", "model"),
+		genai.NewContentFromText("Hello", genai.RoleUser),
+		genai.NewContentFromText("Great to meet you. What would you like to know?", genai.RoleModel),
 	}
 
 	chat, err := client.Chats.Create(ctx, "gemini-2.0-flash", nil, history)
@@ -61,8 +61,8 @@ func ChatStreaming() error {
 	}
 
 	history := []*genai.Content{
-		genai.NewContentFromText("Hello", "user"),
-		genai.NewContentFromText("Great to meet you. What would you like to know?", "model"),
+		genai.NewContentFromText("Hello", genai.RoleUser),
+		genai.NewContentFromText("Great to meet you. What would you like to know?", genai.RoleModel),
 	}
 	chat, err := client.Chats.Create(ctx, "gemini-2.0-flash", nil, history)
 	if err != nil {

--- a/go/controlled_generation.go
+++ b/go/controlled_generation.go
@@ -131,7 +131,7 @@ func JsonEnum() (*genai.GenerateContentResponse, error) {
 		genai.NewPartFromURI(file.URI, file.MIMEType),
 	}
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 
 	response, err := client.Models.GenerateContent(ctx, "gemini-2.0-flash",
@@ -220,7 +220,7 @@ func JsonEnumRaw() (*genai.GenerateContentResponse, error) {
 		genai.NewPartFromURI(file.URI, file.MIMEType),
 	}
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 
 	response, err := client.Models.GenerateContent(ctx, "gemini-2.0-flash",
@@ -290,7 +290,7 @@ func XEnum() (*genai.GenerateContentResponse, error) {
 		genai.NewPartFromURI(file.URI, file.MIMEType),
 	}
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 	response, err := client.Models.GenerateContent(ctx, "gemini-2.0-flash",
 		contents,
@@ -339,7 +339,7 @@ func XEnumRaw() (*genai.GenerateContentResponse, error) {
 		genai.NewPartFromURI(file.URI, file.MIMEType),
 	}
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 	response, err := client.Models.GenerateContent(ctx, "gemini-2.0-flash",
 		contents,

--- a/go/count_tokens.go
+++ b/go/count_tokens.go
@@ -47,7 +47,7 @@ func TokensTextOnly() error {
 
 	// Convert prompt to a slice of *genai.Content using the helper.
 	contents := []*genai.Content{
-		genai.NewContentFromText(prompt, "user"),
+		genai.NewContentFromText(prompt, genai.RoleUser),
 	}
 	countResp, err := client.Models.CountTokens(ctx, "gemini-2.0-flash", contents, nil)
 	if err != nil {
@@ -81,8 +81,8 @@ func TokensChat() error {
 
 	// Initialize chat with some history.
 	history := []*genai.Content{
-		{Role: "user", Parts: []*genai.Part{{Text: "Hi my name is Bob"}}},
-		{Role: "model", Parts: []*genai.Part{{Text: "Hi Bob!"}}},
+		{Role: genai.RoleUser, Parts: []*genai.Part{{Text: "Hi my name is Bob"}}},
+		{Role: genai.RoleModel, Parts: []*genai.Part{{Text: "Hi Bob!"}}},
 	}
 	chat, err := client.Chats.Create(ctx, "gemini-2.0-flash", nil, history)
 	if err != nil {
@@ -104,7 +104,7 @@ func TokensChat() error {
 	fmt.Printf("%#v\n", resp.UsageMetadata)
 
 	// Append an extra user message and recount.
-	extra := genai.NewContentFromText("What is the meaning of life?", "user")
+	extra := genai.NewContentFromText("What is the meaning of life?", genai.RoleUser)
 	hist := chat.History(false)
 	hist = append(hist, extra)
 
@@ -144,7 +144,7 @@ func TokensMultimodalImageFileApi() error {
 		genai.NewPartFromURI(file.URI, file.MIMEType),
 	}
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 
 	tokenResp, err := client.Models.CountTokens(ctx, "gemini-2.0-flash", contents, nil)
@@ -205,7 +205,7 @@ func TokensMultimodalVideoAudioFileApi() error {
 		genai.NewPartFromURI(file.URI, file.MIMEType),
 	}
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 
 	tokenResp, err := client.Models.CountTokens(ctx, "gemini-2.0-flash", contents, nil)
@@ -252,7 +252,7 @@ func TokensMultimodalPdfFileApi() error {
 		genai.NewPartFromURI(file.URI, file.MIMEType),
 	}
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 
 	tokenResp, err := client.Models.CountTokens(ctx, "gemini-2.0-flash", contents, nil)
@@ -299,7 +299,7 @@ func TokensCachedContent() error {
 		genai.NewPartFromURI(file.URI, file.MIMEType),
 	}
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 
 	// Create cached content using a simple slice with text and a file.
@@ -312,14 +312,14 @@ func TokensCachedContent() error {
 
 	prompt := "Please give a short summary of this file."
 	countResp, err := client.Models.CountTokens(ctx, "gemini-2.0-flash", []*genai.Content{
-		genai.NewContentFromText(prompt, "user"),
+		genai.NewContentFromText(prompt, genai.RoleUser),
 	}, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
 	fmt.Printf("%d", countResp.TotalTokens)
 	response, err := client.Models.GenerateContent(ctx, "gemini-1.5-flash-001", []*genai.Content{
-		genai.NewContentFromText(prompt, "user"),
+		genai.NewContentFromText(prompt, genai.RoleUser),
 	}, &genai.GenerateContentConfig{
 		CachedContent: cache.Name,
 	})

--- a/go/embed.go
+++ b/go/embed.go
@@ -24,7 +24,7 @@ func EmbedContent() error {
 	text := "Hello World!"
 	outputDim := int32(10)
 	contents := []*genai.Content{
-		genai.NewContentFromText(text, "user"),
+		genai.NewContentFromText(text, genai.RoleUser),
 	}
 	result, err := client.Models.EmbedContent(ctx, "text-embedding-004", 
 		contents, &genai.EmbedContentConfig{
@@ -55,9 +55,9 @@ func BatchEmbedContents() error {
 	}
 
 	contents := []*genai.Content{
-		genai.NewContentFromText("What is the meaning of life?", "user"),
-		genai.NewContentFromText("How much wood would a woodchuck chuck?", "user"),
-		genai.NewContentFromText("How does the brain work?", "user"),
+		genai.NewContentFromText("What is the meaning of life?", genai.RoleUser),
+		genai.NewContentFromText("How much wood would a woodchuck chuck?", genai.RoleUser),
+		genai.NewContentFromText("How does the brain work?", genai.RoleUser),
 	}
 
 	outputDim := int32(10)

--- a/go/files.go
+++ b/go/files.go
@@ -41,7 +41,7 @@ func FilesCreateText() (*genai.GenerateContentResponse, error) {
 	}
 
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 
 	response, err := client.Models.GenerateContent(ctx, "gemini-2.0-flash", contents, nil)
@@ -83,7 +83,7 @@ func FilesCreateImage() (*genai.GenerateContentResponse, error) {
 	}
 
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 
 	response, err := client.Models.GenerateContent(ctx, "gemini-2.0-flash", contents, nil)
@@ -124,7 +124,7 @@ func FilesCreateAudio() (*genai.GenerateContentResponse, error) {
 	}
 
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 
 	response, err := client.Models.GenerateContent(ctx, "gemini-2.0-flash", contents, nil)
@@ -177,7 +177,7 @@ func FilesCreateVideo() (*genai.GenerateContentResponse, error) {
 	}
 
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 
 	response, err := client.Models.GenerateContent(ctx, "gemini-2.0-flash", contents, nil)
@@ -217,7 +217,7 @@ func FilesCreatePdf() (*genai.GenerateContentResponse, error) {
 	}
 
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 
 	response, err := client.Models.GenerateContent(ctx, "gemini-2.0-flash", contents, nil)
@@ -258,7 +258,7 @@ func FilesCreateFromIO() (*genai.GenerateContentResponse, error) {
 	}
 
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 
 	response, err := client.Models.GenerateContent(ctx, "gemini-2.0-flash", contents, nil)
@@ -356,7 +356,7 @@ func FilesDelete() error {
 	}
 
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 	
 	_, err = client.Models.GenerateContent(ctx, "gemini-2.0-flash", contents, nil)

--- a/go/function_calling.go
+++ b/go/function_calling.go
@@ -91,7 +91,7 @@ func FunctionCalling() error {
 	// Create the content prompt.
 	contents := []*genai.Content{
 		genai.NewContentFromText(
-			"I have 57 cats, each owns 44 mittens, how many mittens is that in total?", "user",
+			"I have 57 cats, each owns 44 mittens, how many mittens is that in total?", genai.RoleUser,
 		),
 	}
 
@@ -149,7 +149,7 @@ func FunctionCalling() error {
 
 	// Prepare the final result message as content.
 	resultContents := []*genai.Content{
-		genai.NewContentFromText("The final result is " + fmt.Sprintf("%v", result), "user"),
+		genai.NewContentFromText("The final result is " + fmt.Sprintf("%v", result), genai.RoleUser),
 	}
 
 	// Use GenerateContent to send the final result.

--- a/go/safety_settings.go
+++ b/go/safety_settings.go
@@ -33,7 +33,7 @@ func SafetySettings() error {
 		},
 	}
 	contents := []*genai.Content{
-		genai.NewContentFromText(unsafePrompt, "user"),
+		genai.NewContentFromText(unsafePrompt, genai.RoleUser),
 	}
 	response, err := client.Models.GenerateContent(ctx, "gemini-2.0-flash", contents, config)
 	if err != nil {
@@ -82,7 +82,7 @@ func SafetySettingsMulti() error {
 		},
 	}
 	contents := []*genai.Content{
-		genai.NewContentFromText(unsafePrompt, "user"),
+		genai.NewContentFromText(unsafePrompt, genai.RoleUser),
 	}
 	response, err := client.Models.GenerateContent(ctx, "gemini-2.0-flash", contents, config)
 	if err != nil {

--- a/go/system_instruction.go
+++ b/go/system_instruction.go
@@ -21,12 +21,12 @@ func SystemInstruction() error {
 
 	// Construct the user message contents.
 	contents := []*genai.Content{
-		genai.NewContentFromText("Good morning! How are you?", "user"),
+		genai.NewContentFromText("Good morning! How are you?", genai.RoleUser),
 	}
 
 	// Set the system instruction as a *genai.Content.
 	config := &genai.GenerateContentConfig{
-		SystemInstruction: genai.NewContentFromText("You are a cat. Your name is Neko.", "user"),
+		SystemInstruction: genai.NewContentFromText("You are a cat. Your name is Neko.", genai.RoleUser),
 	}
 
 	response, err := client.Models.GenerateContent(ctx, "gemini-2.0-flash", contents, config)

--- a/go/text_generation.go
+++ b/go/text_generation.go
@@ -22,7 +22,7 @@ func TextGenTextOnlyPrompt() (*genai.GenerateContentResponse, error) {
 		log.Fatal(err)
 	}
 	contents := []*genai.Content{
-		genai.NewContentFromText("Write a story about a magic backpack.", "user"),
+		genai.NewContentFromText("Write a story about a magic backpack.", genai.RoleUser),
 	}
 	response, err := client.Models.GenerateContent(ctx, "gemini-2.0-flash", contents, nil)
 	if err != nil {
@@ -44,7 +44,7 @@ func TextGenTextOnlyPromptStreaming() error {
 		log.Fatal(err)
 	}
 	contents := []*genai.Content{
-		genai.NewContentFromText("Write a story about a magic backpack.", "user"),
+		genai.NewContentFromText("Write a story about a magic backpack.", genai.RoleUser),
 	}
 	for response, err := range client.Models.GenerateContentStream(
 		ctx,
@@ -87,7 +87,7 @@ func TextGenMultimodalOneImagePrompt() (*genai.GenerateContentResponse, error) {
 		genai.NewPartFromURI(file.URI, file.MIMEType),
 	}
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 
 	response, err := client.Models.GenerateContent(ctx, "gemini-2.0-flash", contents, nil)
@@ -124,7 +124,7 @@ func TextGenMultimodalOneImagePromptStreaming() error {
 		genai.NewPartFromURI(file.URI, file.MIMEType),
 	}
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 	for response, err := range client.Models.GenerateContentStream(
 		ctx,
@@ -181,7 +181,7 @@ func TextGenMultimodalMultiImagePrompt() (*genai.GenerateContentResponse, error)
 	}
 
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 
 	response, err := client.Models.GenerateContent(ctx, "gemini-2.0-flash", contents, nil)
@@ -233,7 +233,7 @@ func TextGenMultimodalMultiImagePromptStreaming() error {
 	}
 
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 
 	for result, err := range client.Models.GenerateContentStream(
@@ -279,7 +279,7 @@ func TextGenMultimodalAudio() (*genai.GenerateContentResponse, error) {
 	}
 
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 
 	response, err := client.Models.GenerateContent(ctx, "gemini-2.0-flash", contents, nil)
@@ -319,7 +319,7 @@ func TextGenMultimodalAudioStreaming() error {
 	}
 
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 
 	for result, err := range client.Models.GenerateContentStream(
@@ -377,7 +377,7 @@ func TextGenMultimodalVideoPrompt() (*genai.GenerateContentResponse, error) {
 	}
 
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 
 	response, err := client.Models.GenerateContent(ctx, "gemini-2.0-flash", contents, nil)
@@ -429,7 +429,7 @@ func TextGenMultimodalVideoPromptStreaming() error {
 	}
 
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 
 	for result, err := range client.Models.GenerateContentStream(
@@ -475,7 +475,7 @@ func TextGenMultimodalPdf() (*genai.GenerateContentResponse, error) {
 	}
 
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 
 	response, err := client.Models.GenerateContent(ctx, "gemini-2.0-flash", contents, nil)
@@ -515,7 +515,7 @@ func TextGenMultimodalPdfStreaming() error {
 	}
 
 	contents := []*genai.Content{
-		genai.NewContentFromParts(parts, "user"),
+		genai.NewContentFromParts(parts, genai.RoleUser),
 	}
 
 	for result, err := range client.Models.GenerateContentStream(

--- a/go/thinking_generation.go
+++ b/go/thinking_generation.go
@@ -36,7 +36,7 @@ func ThinkingTextOnlyPrompt() (*genai.GenerateContentResponse, error) {
 
 	prompt := "Explain the concept of Occam's Razor and provide a simple, everyday example."
 	contents := []*genai.Content{
-		genai.NewContentFromText(prompt, "user"),
+		genai.NewContentFromText(prompt, genai.RoleUser),
 	}
 
 	resp, err := client.Models.GenerateContent(ctx, modelID, contents, nil)
@@ -61,7 +61,7 @@ func ThinkingTextOnlyPromptStreaming() (string, error) {
 
 	prompt := "Explain the concept of Occam's Razor and provide a simple, everyday example."
 	contents := []*genai.Content{
-		genai.NewContentFromText(prompt, "user"),
+		genai.NewContentFromText(prompt, genai.RoleUser),
 	}
 
 	var fullResponse strings.Builder
@@ -101,7 +101,7 @@ func ThinkingLogicPuzzle() (*genai.GenerateContentResponse, error) {
         would you draw from to correctly label all boxes, and why?
         `
 	contents := []*genai.Content{
-		genai.NewContentFromText(prompt, "user"),
+		genai.NewContentFromText(prompt, genai.RoleUser),
 	}
 
 	resp, err := client.Models.GenerateContent(ctx, modelID, contents, nil)
@@ -141,7 +141,7 @@ func ThinkingCodeExplanation() (*genai.GenerateContentResponse, error) {
         print(f"The factorial of 5 is: {result}")
         `
 	contents := []*genai.Content{
-		genai.NewContentFromText(prompt, "user"),
+		genai.NewContentFromText(prompt, genai.RoleUser),
 	}
 
 	resp, err := client.Models.GenerateContent(ctx, modelID, contents, nil)
@@ -169,7 +169,7 @@ func ThinkingCreativeWritingConstraints() (*genai.GenerateContentResponse, error
         mystery in a library, but the story must not contain the letter 'e'.
         `
 	contents := []*genai.Content{
-		genai.NewContentFromText(prompt, "user"),
+		genai.NewContentFromText(prompt, genai.RoleUser),
 	}
 
 	resp, err := client.Models.GenerateContent(ctx, modelID, contents, nil)
@@ -198,7 +198,7 @@ func ThinkingWithSearchTool() (*genai.GenerateContentResponse, error) {
 
 	prompt := "What were the major scientific breakthroughs announced last week?"
 	contents := []*genai.Content{
-		genai.NewContentFromText(prompt, "user"),
+		genai.NewContentFromText(prompt, genai.RoleUser),
 	}
 	config := &genai.GenerateContentConfig{
 		Tools: []*genai.Tool{googleSearchTool},
@@ -231,7 +231,7 @@ func ThinkingWithSearchToolStreaming() (string, error) {
 
 	prompt := "When is the next total solar eclipse visible from mainland Europe?"
 	contents := []*genai.Content{
-		genai.NewContentFromText(prompt, "user"),
+		genai.NewContentFromText(prompt, genai.RoleUser),
 	}
 	config := &genai.GenerateContentConfig{
 		Tools: []*genai.Tool{googleSearchTool},
@@ -282,7 +282,7 @@ func ThinkingCodeExecution() (*genai.GenerateContentResponse, error) {
 	}
 
 	contents := []*genai.Content{
-		genai.NewContentFromText(prompt, "user"),
+		genai.NewContentFromText(prompt, genai.RoleUser),
 	}
 	config := &genai.GenerateContentConfig{
 		Tools: []*genai.Tool{codeExecutionTool}, // Provide the tool
@@ -321,7 +321,7 @@ func ThinkingStructuredOutputJson() (*genai.GenerateContentResponse, error) {
         `
 
 	contents := []*genai.Content{
-		genai.NewContentFromText(prompt, "user"),
+		genai.NewContentFromText(prompt, genai.RoleUser),
 	}
 
 	resp, err := client.Models.GenerateContent(ctx, modelID, contents, nil)


### PR DESCRIPTION
- Use genai's builtin constants (`RoleUser`, `RoleModel`) instead of string literals for the roles wherever necessary
- "user" >> RoleUser
- "model" >> RoleModel 